### PR TITLE
Adds jest and our first snapshot test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+	presets: ['react', 'es2015']
+}

--- a/app/components/footer/__snapshots__/footer.test.jsx.snap
+++ b/app/components/footer/__snapshots__/footer.test.jsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`It renders the footer component 1`] = `
+<footer
+  className="mainFooter card"
+>
+  <h3>
+    HackerYou
+  </h3>
+  <ul>
+    <li>
+      <a
+        href="http://hackeryou.com"
+      >
+        <i
+          className="chalk-link"
+        />
+        hackeryou.com
+      </a>
+    </li>
+    <li>
+      <a
+        href="mailto:info@hackeryou.com"
+      >
+        <i
+          className="chalk-email"
+        />
+        info@hackeryou.com
+      </a>
+    </li>
+    <li>
+      <a
+        href="http://github.com/hackeryou"
+      >
+        <i
+          className="chalk-github"
+        />
+        github.com/hackeryou
+      </a>
+    </li>
+    <li>
+      <a
+        href="http://twitter.com/hackeryou"
+      >
+        <i
+          className="chalk-twitter"
+        />
+        @hackeryou
+      </a>
+    </li>
+  </ul>
+  <p>
+    <strong>
+      Copyright 
+      2017
+       
+      <a
+        className="blackLight"
+        href="http://hackeryou.com"
+      >
+        HackerYou
+      </a>
+    </strong>
+    <br />
+    <small>
+      The contents of this site are the property of HackerYou. No portion of this site is to be shared without permission.
+    </small>
+  </p>
+</footer>
+`;

--- a/app/components/footer/footer.test.jsx
+++ b/app/components/footer/footer.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Footer from './index.jsx';
+
+test('It renders the footer component', () => {
+    const component = renderer.create(
+        <Footer />
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "contributors": [
     {
@@ -15,12 +15,22 @@
     },
     {
       "name": "Ryan Christiani"
+    },
+    {
+      "name": "Sylvia Nguyen"
+    },
+    {
+      "name": "Tiff Nogueira"
+    },
+    {
+      "name": "Simon Bloom"
     }
   ],
   "license": "ISC",
   "devDependencies": {
     "autoprefixer": "^6.1.1",
     "autoprefixer-core": "^6.0.1",
+    "babel-jest": "^19.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babelify": "^7.2.0",
     "browser-sync": "^2.10.0",
@@ -45,6 +55,8 @@
     "gulp-uglify": "^1.2.0",
     "highlight.js": "^9.8.0",
     "history": "^1.13.1",
+    "jest": "^19.0.2",
+    "jest-cli": "^19.0.2",
     "lost": "^6.6.2",
     "pixrem": "^3.0.0",
     "postcss": "^5.0.12",
@@ -65,6 +77,7 @@
     "react-addons-css-transition-group": "^0.14.3",
     "react-notification-system": "^0.2.6",
     "react-sticky": "^3.0.0",
+    "react-test-renderer": "^15.4.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.9.0",
@@ -76,12 +89,12 @@
     "history": "^1.13.0",
     "moment": "^2.10.6",
     "pixrem": "^3.0.0",
-    "react": "^0.14.2",
+    "react": "^15.4.2",
     "react-addons-create-fragment": "^0.14.2",
     "react-codemirror": "^0.3.0",
     "react-copy-to-clipboard": "^3.0.4",
     "react-datepicker": "^0.17.0",
-    "react-dom": "^0.14.2",
+    "react-dom": "^15.4.2",
     "react-dropzone": "^3.0.0",
     "react-remarkable": "^1.1.1",
     "react-router": "^1.0.0-rc4",


### PR DESCRIPTION
In order to get Jest to work, I had to update us to a newer version of React. I've been playing around with it on my local copy of Readme and it seems to be working fine, but if we merge this we should be prepared to rollback the version number and disable tests in case some part of Readme doesn't play nicely with newer versions of React.